### PR TITLE
Avoid compilation problem on some systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ This software is written in C++ and requires the GNU scientific library to run. 
 ```
 g++ -O3 -lgsl *.cpp -o sr
 ```
+On some systems such as gcc, the order of arguments matters, in which case
+compiling with
+```
+g++ -O3 *.cpp -lgsl -lgslcblas -lm -o sr
+```
+may address linker errors.
 
 ## Generating allele frequency bridges
 


### PR DESCRIPTION
We were having problems with linker errors, for example

```
 /tmp/ccssSWF0.o: In function `cbpMeasure::log_transition_density(double, double, double)':
measure.cpp:(.text._ZN10cbpMeasure22log_transition_densityEddd[_ZN10cbpMeasure22log_transition_densityEddd]+0x76): undefined reference to `gsl_sf_bessel_I1_scaled'
/tmp/ccssSWF0.o: In function `flippedCbpMeasure::log_transition_density(double, double, double)':
measure.cpp:(.text._ZN17flippedCbpMeasure22log_transition_densityEddd[_ZN17flippedCbpMeasure22log_transition_densityEddd]+0x8a): undefined reference to `gsl_sf_bessel_I1_scaled'
collect2: error: ld returned 1 exit status
```

This alternative compilation line fixes the problems.