### PR TITLE
bug fix for compilation problems on some linux systems

### DIFF
--- a/param.cpp
+++ b/param.cpp
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <iomanip>
+#include <limits>
 
 void param::updateTuning() {
 	if (numProp > 0) {

--- a/path.cpp
+++ b/path.cpp
@@ -21,6 +21,7 @@
 #include <fstream>
 #include <iostream>
 #include <algorithm>
+#include <limits>
 
 struct compare_index
 {

--- a/settings.cpp
+++ b/settings.cpp
@@ -18,6 +18,7 @@
 #include <fstream>
 #include <sstream>
 #include <iostream>
+#include <algorithm>
 
 settings::settings(int argc, char* const argv[]) {
 	


### PR DESCRIPTION
`selection` would not compile for me with gcc version 4.8.5 (on Ubuntu 4.8.5-2ubuntu1~14.04.1) without explicitly including these libraries